### PR TITLE
eos-extra.xml: Merge in popular apps list from gnome-software eos plugin

### DIFF
--- a/app-info/eos-extra.xml
+++ b/app-info/eos-extra.xml
@@ -26,6 +26,12 @@
     </metadata>
   </component>
   <component type="desktop" merge="append">
+    <id>com.calibre_ebook.calibre.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>com.dropbox.Client.desktop</id>
     <categories>
       <category>Office</category>
@@ -33,11 +39,29 @@
     </categories>
   </component>
   <component type="desktop" merge="append">
+    <id>com.google.Chrome.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>com.microsoft.Skype.desktop</id>
     <categories>
       <category>AudioVideo</category>
       <category>Family</category>
     </categories>
+  </component>
+  <component type="desktop" merge="append">
+    <id>com.transmissionbt.Transmission.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
+    <id>com.valvesoftware.Steam.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>evolution.desktop</id>
@@ -65,6 +89,12 @@
     <metadata>
       <value key="GnomeSoftware::popular-background">https://d3lapyynmdp1i9.cloudfront.net/thumbnails/gnome-control-center/gnome-control-center-thumb.jpg</value>
     </metadata>
+  </component>
+  <component type="desktop" merge="append">
+    <id>io.github.mmstick.FontFinder.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>io.github.Supertux.desktop</id>
@@ -100,6 +130,12 @@
     </metadata>
   </component>
   <component type="desktop" merge="append">
+    <id>org.libreoffice.LibreOffice.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>net.blockout.Blockout2.desktop</id>
     <categories>
       <category>Family</category>
@@ -118,6 +154,15 @@
       <category>Education</category>
       <category>Family</category>
     </categories>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
+    <id>net.scribus.Scribus.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>net.sourceforge.Extremetuxracer.desktop</id>
@@ -145,6 +190,12 @@
     </categories>
   </component>
   <component type="desktop" merge="append">
+    <id>org.audacityteam.Audacity.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>org.debian.alioth.tux4kids.Tuxmath.desktop</id>
     <categories>
       <category>Game</category>
@@ -162,6 +213,18 @@
     <categories>
       <category>Family</category>
     </categories>
+  </component>
+  <component type="desktop" merge="append">
+    <id>org.gimp.GIMP.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
+    <id>org.gnome.chess.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>org.gnome.gedit.desktop</id>
@@ -211,6 +274,12 @@
     </categories>
   </component>
   <component type="desktop" merge="append">
+    <id>org.gnome.SwellFoop.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>org.gnome.Terminal.desktop</id>
     <metadata>
       <value key="GnomeSoftware::popular-background">https://d3lapyynmdp1i9.cloudfront.net/thumbnails/org.gnome.Terminal/org.gnome.terminal-thumb.jpg</value>
@@ -226,6 +295,18 @@
     </metadata>
   </component>
   <component type="desktop" merge="append">
+    <id>org.inkscape.Inkscape.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
+    <id>org.kde.gcompris.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>org.kde.Katomic.desktop</id>
     <categories>
       <category>Education</category>
@@ -236,6 +317,12 @@
     <categories>
       <category>Education</category>
     </categories>
+  </component>
+  <component type="desktop" merge="append">
+    <id>org.kde.krita.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>org.kde.Ktuberling.desktop</id>
@@ -262,6 +349,12 @@
       <category>Education</category>
       <category>Family</category>
     </categories>
+  </component>
+  <component type="desktop" merge="append">
+    <id>org.mozilla.Firefox.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>org.openscad.Openscad.desktop</id>
@@ -294,11 +387,26 @@
     </categories>
   </component>
   <component type="desktop" merge="append">
+    <id>org.telegram.desktop.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
     <id>org.tuxpaint.Tuxpaint.desktop</id>
     <categories>
       <category>Graphics</category>
       <category>Family</category>
     </categories>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+  </component>
+  <component type="desktop" merge="append">
+    <id>org.videolan.VLC.desktop</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
   </component>
   <component type="desktop" merge="append">
     <id>rhythmbox.desktop</id>
@@ -324,6 +432,9 @@
       <category>Utility</category>
       <category>Office</category>
     </categories>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
     <metadata>
       <value key="GnomeSoftware::popular-background">https://d3lapyynmdp1i9.cloudfront.net/thumbnails/simple-scan/simple-scan-thumb.jpg</value>
     </metadata>

--- a/sync-s3.sh
+++ b/sync-s3.sh
@@ -52,7 +52,7 @@ while true; do
 done
 
 # Check that the needed programs exist
-for prog in gzip aws; do
+for prog in gzip aws appstream-util; do
     if ! type -p $prog >/dev/null; then
         echo "Cannot find $prog program" >&2
         exit 1
@@ -60,10 +60,13 @@ for prog in gzip aws; do
 done
 
 # Create the eos-extra.xml.gz file if it doesn't exist or is older than
-# eos-extra.xml
+# eos-extra.xml. Validate it first.
 XML="$SRCDIR/app-info/eos-extra.xml"
 XML_GZ="$SRCDIR/s3/app-info/eos-extra.xml.gz"
 XML_GZ_CSUM="${XML_GZ}.sha256sum"
+
+appstream-util validate-strict --nonet "$XML"
+
 mkdir -p "$SRCDIR/s3/app-info"
 if [ ! -f "$XML_GZ" ] || [ "$XML" -nt "$XML_GZ" ]; then
     echo "Generating $XML_GZ"


### PR DESCRIPTION
Previously, the list of featured apps to present in gnome-software in
Endless OS was hardcoded in the `eos` plugin in our fork of
gnome-software. That’s not very maintainable, and means that the list of
popular apps can only be updated once per OS release.

Instead, provide the list using the existing eos-extra.xml file, which
is set in gnome-software’s `external-appstream-urls` list and which
gnome-software will update automatically when connected to the internet.

Some of these apps were in eos-extra.xml already; in those cases, add
the kudos to the existing component element.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T26507