### PR TITLE
eos-extra.xml: Fix indentation and <bundle> element nesting

### DIFF
--- a/app-info/eos-extra.xml
+++ b/app-info/eos-extra.xml
@@ -30,7 +30,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>com.dropbox.Client.desktop</id>
@@ -44,8 +44,8 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
+    <bundle type="flatpak"></bundle>
   </component>
-  <bundle type="flatpak"></bundle>
   <component type="desktop" merge="append">
     <id>com.microsoft.Skype.desktop</id>
     <categories>
@@ -58,14 +58,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>com.valvesoftware.Steam</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>evolution.desktop</id>
@@ -99,7 +99,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>io.github.Supertux.desktop</id>
@@ -139,7 +139,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>net.blockout.Blockout2.desktop</id>
@@ -163,14 +163,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>net.scribus.Scribus</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>net.sourceforge.Extremetuxracer.desktop</id>
@@ -202,8 +202,8 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
+    <bundle type="flatpak"></bundle>
   </component>
-  <bundle type="flatpak"></bundle>
   <component type="desktop" merge="append">
     <id>org.debian.alioth.tux4kids.Tuxmath.desktop</id>
     <categories>
@@ -228,14 +228,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.gnome.Chess</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.gnome.gedit.desktop</id>
@@ -289,8 +289,8 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
+    <bundle type="flatpak"></bundle>
   </component>
-  <bundle type="flatpak"></bundle>
   <component type="desktop" merge="append">
     <id>org.gnome.Terminal.desktop</id>
     <metadata>
@@ -311,14 +311,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
+    <bundle type="flatpak"></bundle>
   </component>
-  <bundle type="flatpak"></bundle>
   <component type="desktop" merge="append">
     <id>org.kde.gcompris</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.kde.Katomic.desktop</id>
@@ -337,7 +337,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.kde.Ktuberling.desktop</id>
@@ -370,7 +370,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.openscad.Openscad.desktop</id>
@@ -407,7 +407,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.tuxpaint.Tuxpaint</id>
@@ -418,14 +418,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.videolan.VLC</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-  <bundle type="flatpak"></bundle>
+    <bundle type="flatpak"></bundle>
   </component>
   <component type="desktop" merge="append">
     <id>rhythmbox.desktop</id>


### PR DESCRIPTION
Follow-up to https://github.com/endlessm/gnome-software-data/pull/11

https://phabricator.endlessm.com/T26507