### PR TITLE
eos-extra: Specify ref for each application

### DIFF
--- a/app-info/eos-extra.xml
+++ b/app-info/eos-extra.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<components version="0.8" origin="flathub">
+<components version="0.8">
   <component type="desktop" merge="append">
     <id>brasero.desktop</id>
     <categories>
@@ -30,7 +30,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/com.calibre_ebook.calibre//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>com.dropbox.Client.desktop</id>
@@ -44,7 +44,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/com.google.Chrome//eos3</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>com.microsoft.Skype.desktop</id>
@@ -58,14 +58,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/com.transmissionbt.Transmission//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>com.valvesoftware.Steam</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/com.valvesoftware.Steam//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>evolution.desktop</id>
@@ -99,7 +99,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/io.github.mmstick.FontFinder//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>io.github.Supertux.desktop</id>
@@ -139,7 +139,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.libreoffice.LibreOffice//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>net.blockout.Blockout2.desktop</id>
@@ -163,14 +163,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/net.minetest.Minetest//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>net.scribus.Scribus</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/net.scribus.Scribus//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>net.sourceforge.Extremetuxracer.desktop</id>
@@ -202,7 +202,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.audacity.Audacity//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.debian.alioth.tux4kids.Tuxmath.desktop</id>
@@ -228,14 +228,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.gimp.GIMP//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.gnome.Chess</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.gnome.Chess//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.gnome.gedit.desktop</id>
@@ -289,7 +289,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.gnome.SwellFoop//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.gnome.Terminal.desktop</id>
@@ -311,14 +311,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.inkscape.Inkscape//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.kde.gcompris</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.kde.gcompris//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.kde.Katomic.desktop</id>
@@ -337,7 +337,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.kde.krita//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.kde.Ktuberling.desktop</id>
@@ -370,7 +370,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.mozilla.Firefox//eos3</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.openscad.Openscad.desktop</id>
@@ -407,7 +407,7 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.telegram.desktop//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.tuxpaint.Tuxpaint</id>
@@ -418,14 +418,14 @@
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.tuxpaint.Tuxpaint//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>org.videolan.VLC</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>
     </kudos>
-    <bundle type="flatpak"></bundle>
+    <bundle type="flatpak">app/org.videolan.VLC//stable</bundle>
   </component>
   <component type="desktop" merge="append">
     <id>rhythmbox.desktop</id>


### PR DESCRIPTION
Earlier the refs were not specified in eos-extra because of their
arch-dependent nature. As per [1], gnome-software can resolve
the default arch for the current platform.

[1] https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/297

After consulting with upstream maintainers, they specified that the
 "origin" property for external-appstream is not necessary although
the appstream standard mentions it as a mandatory property.
As eos-extra comprises of apps belonging to different remote, the
"origin" for that specific app can be computed by gnome-software
itself. Hence, we drop the "origin" property from this external
appstream file.

https://phabricator.endlessm.com/T26507