### PR TITLE
Feature Zoom

### DIFF
--- a/app-info/eos-extra.xml
+++ b/app-info/eos-extra.xml
@@ -1837,4 +1837,11 @@
     </kudos>
     <bundle type="flatpak"/>
   </component>
+  <component type="desktop" merge="append">
+    <id>us.zoom.Zoom</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+    <bundle type="flatpak"/>
+  </component>
 </components>


### PR DESCRIPTION
This app is very widely used during the COVID-19 crisis. New systems
have a Get Zoom icon on the desktop; let's promote the existence of this
Flatpak a little to existing users.

https://phabricator.endlessm.com/T30094