### PR TITLE
app-info: Feature Warp

### DIFF
--- a/app-info/eos-extra.txt
+++ b/app-info/eos-extra.txt
@@ -1,3 +1,4 @@
+app.drey.Warp
 cc.arduino.arduinoide
 com.calibre_ebook.calibre
 com.dropbox.Client

--- a/app-info/eos-extra.xml
+++ b/app-info/eos-extra.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <components version="0.8" origin="flathub">
   <component type="desktop" merge="append">
+    <id>app.drey.Warp</id>
+    <kudos>
+      <kudo>GnomeSoftware::popular</kudo>
+    </kudos>
+    <custom>
+      <value key="GnomeSoftware::FeatureTile">True</value>
+    </custom>
+    <categories>
+      <category>Utility</category>
+      <category>Featured</category>
+    </categories>
+    <bundle type="flatpak">app/app.drey.Warp/x86_64/stable</bundle>
+  </component>
+
+  <component type="desktop" merge="append">
     <id>cc.arduino.arduinoide</id>
     <kudos>
       <kudo>GnomeSoftware::popular</kudo>


### PR DESCRIPTION
Some time ago, our friends at [SOMAS][1] shared with us
a curated list of apps from Flathub. One app on the list is
[Teleport][0] which can be used to share files on the local network.

Unfortunately Teleport is unmaintained, and has some bugs that make me
hesitate to feature it. (Most importantly, the only way to accept an
incoming file is to mouse over the notification, and click the button
that is revealed. If you mouse away from the notification, it disappears
into the notification tray, and there is no way to get the buttons
back.)

[Warp][2] is a similar app. Unfortunately it requires an internet
connection, but only for signalling: the data itself is transferred over
the local network if possible. And for online users, it allows you to
send files over the internet.

Add it to the featured apps list.

[0]: https://flathub.org/apps/details/com.frac_tion.teleport
[1]: https://somas.org.br/
[2]: https://gitlab.gnome.org/World/warp/
