### PR TITLE
Use new CloudFront CNAME

### DIFF
--- a/app-info/README.md
+++ b/app-info/README.md
@@ -7,7 +7,7 @@ in GNOME Software.
 The Endless-specific infrastructure is:
 
 * Our external-appstream is currently a file named `org.gnome.Software-eos-extra.xml.gz` and can be found in `/var/cache/app-info/xmls/`. The contents of this file are [here](./eos-extra.xml).
-* The content of `eos-extra.xml` are published to an [S3 URL](https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz) via [this job](https://ci.endlessm-sf.com/job/gnome-software-data/).
+* The content of `eos-extra.xml` are published to an [S3 URL](https://appstream.endlessos.org/app-info/eos-extra.xml.gz) via [this job](https://ci.endlessm-sf.com/job/gnome-software-data/).
 * The S3 URL [is preset](https://github.com/endlessm/eos-theme/blob/9bd2312ad7650654c09f4267759ea6217a8d9d40/settings/com.endlessm.settings.gschema.override.in#L121) as the `external-appstream-urls` GSetting for `org.gnome.software` when images are built. The external-appstream plugin of gnome-software fetches the file at this S3 URL and places it at `/var/cache/app-info/xmls/org.gnome.Software-eos-extra.xml.gz` on disk.
 * We mention `<bundle type="flatpak"/>` in the `eos-extra.xml` so that the wildcard apps created by the external-appstream file can be adopted by the flatpak plugin. See `gs_plugin_adopt_app()`.
 
@@ -27,7 +27,7 @@ configuration, using the upstream functionality.
 * Run [pwa-metainfo-generator.py](./pwa-metainfo-generator.py)
 * If necessary, add screenshots in [s3/screenshots](../s3/screenshots)
   in a subdirectory named by with the generated app ID. Use
-  `https://d3lapyynmdp1i9.cloudfront.net/` as the base URL in the YAML
+  `https://appstream.endlessos.org/` as the base URL in the YAML
   configuration. Run `pwa-metainfo-generator.py` again.
 * Run [generate-eos-extra-appstream](./generate-eos-extra-appstream)
 * Commit the result and submit a pull request

--- a/app-info/eos-extra-pwa.yaml
+++ b/app-info/eos-extra-pwa.yaml
@@ -22,40 +22,40 @@
     - social-contacts=intense
   adaptive: true
   screenshots:
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot1.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot1.png
       default: true
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot2.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot2.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot3.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot3.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot4.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot4.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot5.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot5.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot6.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot6.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot7.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot7.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot8.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot8.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot9.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot9.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot10.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot10.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot11.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot11.png
       width: 900
       height: 900
-    - src: https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png
+    - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png
       width: 900
       height: 900

--- a/app-info/eos-extra.xml
+++ b/app-info/eos-extra.xml
@@ -1894,40 +1894,40 @@ staff.</p>
     <icon type="remote" width="512" height="512">https://uploads-community-endlessos-com.s3.dualstack.us-west-2.amazonaws.com/optimized/1X/8eff890b1bc1880b0077955aba6e2e76223a1365_2_512x512.jpg</icon>
     <screenshots>
       <screenshot type="default">
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot1.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot1.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot2.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot2.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot3.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot3.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot4.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot4.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot5.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot5.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot6.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot6.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot7.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot7.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot8.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot8.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot9.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot9.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot10.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot10.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot11.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot11.png</image>
       </screenshot>
       <screenshot>
-        <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png</image>
+        <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png</image>
       </screenshot>
     </screenshots>
     <categories>

--- a/app-info/metainfo/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec.metainfo.xml
@@ -18,40 +18,40 @@ staff.</p>
   <icon type="remote" width="512" height="512">https://uploads-community-endlessos-com.s3.dualstack.us-west-2.amazonaws.com/optimized/1X/8eff890b1bc1880b0077955aba6e2e76223a1365_2_512x512.jpg</icon>
   <screenshots>
     <screenshot type="default">
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot1.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot1.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot2.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot2.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot3.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot3.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot4.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot4.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot5.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot5.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot6.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot6.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot7.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot7.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot8.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot8.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot9.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot9.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot10.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot10.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot11.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot11.png</image>
     </screenshot>
     <screenshot>
-      <image width="900" height="900">https://d3lapyynmdp1i9.cloudfront.net/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png</image>
+      <image width="900" height="900">https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png</image>
     </screenshot>
   </screenshots>
   <categories>


### PR DESCRIPTION
A nicer appstream.endlessos.org CNAME is being connected to the CloudFront CDN. Use that instead of the direct distribution domain name. These changes were generated with the following command:

```
git grep -l d3lapyynmdp1i9.cloudfront.net | \
  xargs sed -i 's/d3lapyynmdp1i9.cloudfront.net/appstream.endlessos.org/g'
```

This depends on endlessm/eos-administration#1303 being deployed.

https://phabricator.endlessm.com/T28855