### PR TITLE
T34555: Adding sites from gnome-pwa-lists

### DIFF
--- a/app-info/eos-extra-pwa.yaml
+++ b/app-info/eos-extra-pwa.yaml
@@ -79,7 +79,8 @@
   adaptive: true
 - url: https://pinafore.social/
   name_property: name
-  description: An alternative web client for Mastodon, focused on speed and simplicity.
+  summary: An alternative web client for Mastodon, focused on speed and simplicity.
+  description: 
   license: AGPL-3.0-only
   categories:
     - Chat
@@ -114,7 +115,6 @@
   adaptive: true
 - url: https://squoosh.app/
   name_property: name
-  summary: Squoosh
   description: Squoosh is the ultimate image optimizer that allows you to compress and compare images with different codecs in your browser.
   license: Apache-2.0
   categories:
@@ -128,7 +128,7 @@
   adaptive: true
 - url: https://excalidraw.com/
   name_property: name
-  summary: Excalidraw — Collaborative whiteboarding made easy
+  summary: Collaborative whiteboarding made easy
   description: Excalidraw is a virtual collaborative whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them.
   license: MIT
   categories:
@@ -209,8 +209,7 @@
   adaptive: true
 - url: https://www.instagram.com/
   name_property: name
-  summary: Instagram
-  description: Create an account or log in to Instagram - A simple, fun & creative way to capture, edit & share photos, videos & messages with friends & family.
+  description: A simple, fun & creative way to capture, edit & share photos, videos & messages with friends & family.
   license: LicenseRef-proprietary
   categories:
     - Chat
@@ -228,7 +227,6 @@
   adaptive: true
 - url: https://www.pinterest.com/
   name_property: name
-  summary: Pinterest
   description: Discover recipes, home ideas, style inspiration and other ideas to try.
   license: LicenseRef-proprietary
   categories:

--- a/app-info/eos-extra-pwa.yaml
+++ b/app-info/eos-extra-pwa.yaml
@@ -59,3 +59,188 @@
     - src: https://appstream.endlessos.org/screenshots/org.gnome.Software.WebApp_5c818dd1c0c3cad43709490cb72217f0d08912ec/screenshot12.png
       width: 900
       height: 900
+- url: https://app.diagrams.net
+  name_property: name
+  summary: draw.io is free online diagram software for making flowcharts, process diagrams, org charts, UML, ER and network diagrams
+  description: draw.io is a free online diagramming application and flowchart maker . You can use it to create UML, entity relationship, org charts, BPMN and BPM, database schema and networks. Also possible are telecommunication network, workflow, flowcharts, maps overlays and GIS, electronic circuit and social network diagrams.
+  license: Apache-2.0
+  categories:
+    - Programming and Developer Software
+  keywords:
+    - drawio
+    - diagram
+    - FlowChart
+    - online
+    - flowchart maker
+    - uml
+    - erd
+  content_rating:
+    - social-info=mild
+  adaptive: true
+- url: https://pinafore.social/
+  name_property: name
+  description: An alternative web client for Mastodon, focused on speed and simplicity.
+  license: AGPL-3.0-only
+  categories:
+    - Chat
+  content_rating:
+    - social-audio=intense
+    - social-info=none
+  adaptive: true
+- url: https://snapdrop.net/
+  name_property: name
+  summary: Local network file sharing in your browser
+  description: Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.
+  license: GPL-3.0-only
+  developer_name: RobinLinus
+  categories:
+    - Programming and Developer Software
+  keywords:
+    - File
+    - Transfer
+    - Share
+    - Peer2Peer
+  content_rating:
+    - social-info=mild
+  adaptive: true
+- url: https://stackedit.io/app
+  name_property: name
+  description: Free, open-source, full-featured Markdown editor.
+  license: Apache-2.0
+  categories:
+    - Programming and Developer Software
+  content_rating:
+      - social-info=mild
+  adaptive: true
+- url: https://squoosh.app/
+  name_property: name
+  summary: Squoosh
+  description: Squoosh is the ultimate image optimizer that allows you to compress and compare images with different codecs in your browser.
+  license: Apache-2.0
+  categories:
+    - Graphics Multimedia and Web Design
+  keywords:
+    - FileTools
+    - Image
+    - Processing
+  content_rating:
+    - social-info=moderate
+  adaptive: true
+- url: https://excalidraw.com/
+  name_property: name
+  summary: Excalidraw — Collaborative whiteboarding made easy
+  description: Excalidraw is a virtual collaborative whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them.
+  license: MIT
+  categories:
+    - Programming and Developer Software
+  keywords:
+    - Office
+    - Education
+  content_rating:
+    - social-info=moderate
+  adaptive: true
+- url: https://discourse.gnome.org/
+  name_property: name
+  summary: GNOME Discourse
+  description: GNOME Project and Community related discussions
+  license: GPL-2.0-or-later
+  categories:
+    - Chat
+  keywords:
+    - GNOME
+    - forum
+    - support
+  content_rating:
+      - social-info=moderate
+      - social-audio=moderate
+      - social-contacts=intense
+  adaptive: true
+- url: https://discourse.flathub.org/
+  name_property: name
+  summary: Flathub Discourse
+  description: A place for Flathub Contributors and Users
+  license: GPL-2.0-or-later
+  categories:
+    - Chat
+  keywords:
+    - Flatpak
+    - forum
+    - support
+  content_rating:
+    - social-info=moderate
+    - social-audio=moderate
+    - social-contacts=intense
+  adaptive: true
+- url: https://devdocs.io/
+  name_property: name
+  summary: DevDocs
+  description: Fast, offline, and free documentation browser for developers. Search 100+ docs in one web app including HTML, CSS, JavaScript, PHP, Ruby, Python, Go, C, C++, and many more.
+  license: MPL-2.0
+  categories:
+    - Programming and Developer Software
+  keywords:
+    - Documentation
+    - Development
+  content_rating:
+    - social-info=moderate
+  adaptive: true
+- url: https://twitter.com/
+  name_property: name
+  summary: Twitter
+  description: The latest stories on Twitter - as told by Tweets.
+  license: LicenseRef-proprietary
+  categories:
+    - Chat
+  content_rating:
+    - social-info=intense
+    - social-audio=moderate
+  adaptive: true
+- url: https://todoist.com/
+  name_property: name
+  summary: A to-do list to organize your work and life
+  description: Trusted by 30 million people and teams. Todoist is the world's favorite task manager and to-do list app. Finally become focused, organized and calm.
+  license: LicenseRef-proprietary
+  categories:
+    - Programming and Developer Software
+  keywords:
+    - Office
+  content_rating:
+    - social-info=moderate
+  adaptive: true
+- url: https://www.instagram.com/
+  name_property: name
+  summary: Instagram
+  description: Create an account or log in to Instagram - A simple, fun & creative way to capture, edit & share photos, videos & messages with friends & family.
+  license: LicenseRef-proprietary
+  categories:
+    - Chat
+  keywords:
+    - Photography
+    - Graphics
+  content_rating:
+    - sex-themes=mild
+    - social-chat=intense
+    - social-info=intense
+    - social-audio=intense
+    - social-location=intense
+    - social-contacts=intense
+    - money-advertising=intense
+  adaptive: true
+- url: https://www.pinterest.com/
+  name_property: name
+  summary: Pinterest
+  description: Discover recipes, home ideas, style inspiration and other ideas to try.
+  license: LicenseRef-proprietary
+  categories:
+    - Chat
+  keywords:
+    - Photography
+    - Graphics
+  content_rating:
+    - drugs-alcohol=mild
+    - sex-nudity=mild
+    - sex-themes=mild
+    - social-chat=intense
+    - social-info=moderate
+    - money-advertising=intense
+  adaptive: true

--- a/app-info/metainfo/org.gnome.Software.WebApp_02310f2fd700a63d17ecc2d4b261f6956d8a0193.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_02310f2fd700a63d17ecc2d4b261f6956d8a0193.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_02310f2fd700a63d17ecc2d4b261f6956d8a0193.desktop</id>
+  <name>Flathub Discourse</name>
+  <launchable type="url">https://discourse.flathub.org/</launchable>
+  <url type="homepage">https://discourse.flathub.org/</url>
+  <summary>Flathub Discourse</summary>
+  <description>A place for Flathub Contributors and Users</description>
+  <project_license>GPL-2.0-or-later</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="512" height="512">https://discourse-flathub-org-uploads.s3.dualstack.us-east-1.amazonaws.com/optimized/1X/be4563846333bda6607c6c3c5b226dff9d213866_2_512x512.png</icon>
+  <categories>
+    <category>Chat</category>
+  </categories>
+  <keywords>
+    <keyword>Flatpak</keyword>
+    <keyword>forum</keyword>
+    <keyword>support</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+    <content_attribute id="social-audio">moderate</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_02310f2fd700a63d17ecc2d4b261f6956d8a0193.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_02310f2fd700a63d17ecc2d4b261f6956d8a0193.metainfo.xml
@@ -4,10 +4,11 @@
   <name>Flathub Discourse</name>
   <launchable type="url">https://discourse.flathub.org/</launchable>
   <url type="homepage">https://discourse.flathub.org/</url>
-  <summary>Flathub Discourse</summary>
-  <description>A place for Flathub Contributors and Users</description>
+  <summary>A forum for Flathub users</summary>
+  <description>Flathub aims to be the place to get and distribute apps for Linux. It is powered by Flatpak which allows Flathub apps to run on almost any Linux distribution.</description>
   <project_license>GPL-2.0-or-later</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Flathub</developer_name>
   <icon type="remote" width="512" height="512">https://discourse-flathub-org-uploads.s3.dualstack.us-east-1.amazonaws.com/optimized/1X/be4563846333bda6607c6c3c5b226dff9d213866_2_512x512.png</icon>
   <categories>
     <category>Chat</category>

--- a/app-info/metainfo/org.gnome.Software.WebApp_4dda9043da5b2d2aa57c6064c907c1ae3fe58941.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_4dda9043da5b2d2aa57c6064c907c1ae3fe58941.metainfo.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_4dda9043da5b2d2aa57c6064c907c1ae3fe58941.desktop</id>
+  <name>Snapdrop</name>
+  <launchable type="url">https://snapdrop.net/</launchable>
+  <url type="homepage">https://snapdrop.net/</url>
+  <summary>Local network file sharing in your browser</summary>
+  <description>Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.</description>
+  <project_license>GPL-3.0-only</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <developer_name>RobinLinus</developer_name>
+  <icon type="remote" width="192" height="192">https://snapdrop.net/images/android-chrome-192x192.png</icon>
+  <icon type="remote" width="512" height="512">https://snapdrop.net/images/android-chrome-512x512.png</icon>
+  <icon type="remote" width="96" height="96">https://snapdrop.net/images/favicon-96x96.png</icon>
+  <categories>
+    <category>Programming and Developer Software</category>
+  </categories>
+  <keywords>
+    <keyword>File</keyword>
+    <keyword>Transfer</keyword>
+    <keyword>Share</keyword>
+    <keyword>Peer2Peer</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_510edbf11e660dee9847c587d8683808adabe9bf.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_510edbf11e660dee9847c587d8683808adabe9bf.metainfo.xml
@@ -8,6 +8,7 @@
   <description>draw.io is a free online diagramming application and flowchart maker . You can use it to create UML, entity relationship, org charts, BPMN and BPM, database schema and networks. Also possible are telecommunication network, workflow, flowcharts, maps overlays and GIS, electronic circuit and social network diagrams.</description>
   <project_license>Apache-2.0</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>JGraph Ltd</developer_name>
   <icon type="remote" width="512" height="512">https://app.diagrams.net/images/android-chrome-512x512.png</icon>
   <categories>
     <category>Programming and Developer Software</category>

--- a/app-info/metainfo/org.gnome.Software.WebApp_510edbf11e660dee9847c587d8683808adabe9bf.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_510edbf11e660dee9847c587d8683808adabe9bf.metainfo.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_510edbf11e660dee9847c587d8683808adabe9bf.desktop</id>
+  <name>diagrams.net</name>
+  <launchable type="url">https://app.diagrams.net</launchable>
+  <url type="homepage">https://app.diagrams.net</url>
+  <summary>draw.io is free online diagram software for making flowcharts, process diagrams, org charts, UML, ER and network diagrams</summary>
+  <description>draw.io is a free online diagramming application and flowchart maker . You can use it to create UML, entity relationship, org charts, BPMN and BPM, database schema and networks. Also possible are telecommunication network, workflow, flowcharts, maps overlays and GIS, electronic circuit and social network diagrams.</description>
+  <project_license>Apache-2.0</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="512" height="512">https://app.diagrams.net/images/android-chrome-512x512.png</icon>
+  <categories>
+    <category>Programming and Developer Software</category>
+  </categories>
+  <keywords>
+    <keyword>drawio</keyword>
+    <keyword>diagram</keyword>
+    <keyword>FlowChart</keyword>
+    <keyword>online</keyword>
+    <keyword>flowchart maker</keyword>
+    <keyword>uml</keyword>
+    <keyword>erd</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_5ea0d5a0681e425022d889f3e355de2f19f92070.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_5ea0d5a0681e425022d889f3e355de2f19f92070.metainfo.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_5ea0d5a0681e425022d889f3e355de2f19f92070.desktop</id>
+  <name>Twitter</name>
+  <launchable type="url">https://twitter.com/</launchable>
+  <url type="homepage">https://twitter.com/</url>
+  <summary>Twitter</summary>
+  <description>The latest stories on Twitter - as told by Tweets.</description>
+  <project_license>LicenseRef-proprietary</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="192" height="192">https://abs.twimg.com/responsive-web/client-web-legacy/icon-default.ee534d8a.png</icon>
+  <icon type="remote" width="512" height="512">https://abs.twimg.com/responsive-web/client-web-legacy/icon-default-large.8e027b6a.png</icon>
+  <screenshots>
+    <screenshot type="default">
+      <image width="586" height="1041">https://abs.twimg.com/responsive-web/client-web-legacy/twitter-lite-data-saver-marketing.6805986a.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="586" height="1041">https://abs.twimg.com/responsive-web/client-web-legacy/twitter-lite-explore-marketing.fd45b02a.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="586" height="1041">https://abs.twimg.com/responsive-web/client-web-legacy/twitter-lite-timeline-marketing.befcdb4a.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Chat</category>
+    <category>News</category>
+    <category>News</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">intense</content_attribute>
+    <content_attribute id="social-audio">moderate</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_5ea0d5a0681e425022d889f3e355de2f19f92070.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_5ea0d5a0681e425022d889f3e355de2f19f92070.metainfo.xml
@@ -4,10 +4,11 @@
   <name>Twitter</name>
   <launchable type="url">https://twitter.com/</launchable>
   <url type="homepage">https://twitter.com/</url>
-  <summary>Twitter</summary>
-  <description>The latest stories on Twitter - as told by Tweets.</description>
+  <summary>The latest stories on Twitter - as told by Tweets</summary>
+  <description>Twitter is what’s happening and what people are talking about right now.</description>
   <project_license>LicenseRef-proprietary</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Twitter Inc.</developer_name>
   <icon type="remote" width="192" height="192">https://abs.twimg.com/responsive-web/client-web-legacy/icon-default.ee534d8a.png</icon>
   <icon type="remote" width="512" height="512">https://abs.twimg.com/responsive-web/client-web-legacy/icon-default-large.8e027b6a.png</icon>
   <screenshots>
@@ -22,10 +23,15 @@
     </screenshot>
   </screenshots>
   <categories>
+    <category>Chat, InstantMessaging, Video, Audio</category>
     <category>Chat</category>
     <category>News</category>
     <category>News</category>
   </categories>
+  <keywords>
+    <keyword>Tweet</keyword>
+    <keyword>Bootstrap</keyword>
+  </keywords>
   <content_rating type="oars-1.1">
     <content_attribute id="social-info">intense</content_attribute>
     <content_attribute id="social-audio">moderate</content_attribute>

--- a/app-info/metainfo/org.gnome.Software.WebApp_6a26263aa32636b9fd0352fd6c8da5dca14ef1d7.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_6a26263aa32636b9fd0352fd6c8da5dca14ef1d7.metainfo.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_6a26263aa32636b9fd0352fd6c8da5dca14ef1d7.desktop</id>
+  <name>Pinterest</name>
+  <launchable type="url">https://www.pinterest.com/</launchable>
+  <url type="homepage">https://www.pinterest.com/</url>
+  <summary>Pinterest</summary>
+  <description>Discover recipes, home ideas, style inspiration and other ideas to try.</description>
+  <project_license>LicenseRef-proprietary</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="192" height="192">https://s.pinimg.com/images/favicon_red_192.png</icon>
+  <categories>
+    <category>Chat</category>
+  </categories>
+  <keywords>
+    <keyword>Photography</keyword>
+    <keyword>Graphics</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="drugs-alcohol">mild</content_attribute>
+    <content_attribute id="sex-nudity">mild</content_attribute>
+    <content_attribute id="sex-themes">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">moderate</content_attribute>
+    <content_attribute id="money-advertising">intense</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_6a26263aa32636b9fd0352fd6c8da5dca14ef1d7.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_6a26263aa32636b9fd0352fd6c8da5dca14ef1d7.metainfo.xml
@@ -4,10 +4,11 @@
   <name>Pinterest</name>
   <launchable type="url">https://www.pinterest.com/</launchable>
   <url type="homepage">https://www.pinterest.com/</url>
-  <summary>Pinterest</summary>
-  <description>Discover recipes, home ideas, style inspiration and other ideas to try.</description>
+  <summary>Discover recipes, home ideas, style inspiration and other ideas to try</summary>
+  <description>Pinterest is a visual discovery engine for finding ideas like recipes, home and style inspiration, and more.</description>
   <project_license>LicenseRef-proprietary</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Pinterest</developer_name>
   <icon type="remote" width="192" height="192">https://s.pinimg.com/images/favicon_red_192.png</icon>
   <categories>
     <category>Chat</category>

--- a/app-info/metainfo/org.gnome.Software.WebApp_962f69328d6450369f25a6fdb6bbd1764d11a3c8.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_962f69328d6450369f25a6fdb6bbd1764d11a3c8.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_962f69328d6450369f25a6fdb6bbd1764d11a3c8.desktop</id>
+  <name>DevDocs</name>
+  <launchable type="url">https://devdocs.io/</launchable>
+  <url type="homepage">https://devdocs.io/</url>
+  <summary>DevDocs</summary>
+  <description>Fast, offline, and free documentation browser for developers. Search 100+ docs in one web app including HTML, CSS, JavaScript, PHP, Ruby, Python, Go, C, C++, and many more.</description>
+  <project_license>MPL-2.0</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="32" height="32">https://devdocs.io/images/webapp-icon-32.png</icon>
+  <icon type="remote" width="60" height="60">https://devdocs.io/images/webapp-icon-60.png</icon>
+  <icon type="remote" width="80" height="80">https://devdocs.io/images/webapp-icon-80.png</icon>
+  <icon type="remote" width="128" height="128">https://devdocs.io/images/webapp-icon-128.png</icon>
+  <icon type="remote" width="192" height="192">https://devdocs.io/images/webapp-icon-192.png</icon>
+  <icon type="remote" width="256" height="256">https://devdocs.io/images/webapp-icon-256.png</icon>
+  <icon type="remote" width="512" height="512">https://devdocs.io/images/webapp-icon-512.png</icon>
+  <categories>
+    <category>Programming and Developer Software</category>
+  </categories>
+  <keywords>
+    <keyword>Documentation</keyword>
+    <keyword>Development</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_962f69328d6450369f25a6fdb6bbd1764d11a3c8.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_962f69328d6450369f25a6fdb6bbd1764d11a3c8.metainfo.xml
@@ -4,10 +4,11 @@
   <name>DevDocs</name>
   <launchable type="url">https://devdocs.io/</launchable>
   <url type="homepage">https://devdocs.io/</url>
-  <summary>DevDocs</summary>
+  <summary>DevDocs combines multiple API documentations in a fast, organized, and searchable interface</summary>
   <description>Fast, offline, and free documentation browser for developers. Search 100+ docs in one web app including HTML, CSS, JavaScript, PHP, Ruby, Python, Go, C, C++, and many more.</description>
   <project_license>MPL-2.0</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Thibaut Courouble</developer_name>
   <icon type="remote" width="32" height="32">https://devdocs.io/images/webapp-icon-32.png</icon>
   <icon type="remote" width="60" height="60">https://devdocs.io/images/webapp-icon-60.png</icon>
   <icon type="remote" width="80" height="80">https://devdocs.io/images/webapp-icon-80.png</icon>

--- a/app-info/metainfo/org.gnome.Software.WebApp_bafc11e1d98eaadbe4dd47c9f27674df9018cfd1.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_bafc11e1d98eaadbe4dd47c9f27674df9018cfd1.metainfo.xml
@@ -8,6 +8,7 @@
   <description>Trusted by 30 million people and teams. Todoist is the world's favorite task manager and to-do list app. Finally become focused, organized and calm.</description>
   <project_license>LicenseRef-proprietary</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Doist Inc.</developer_name>
   <icon type="remote" width="192" height="192">https://todoist.com/static/android-chrome-192x192.png</icon>
   <icon type="remote" width="256" height="256">https://todoist.com/static/android-chrome-256x256.png</icon>
   <categories>

--- a/app-info/metainfo/org.gnome.Software.WebApp_bafc11e1d98eaadbe4dd47c9f27674df9018cfd1.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_bafc11e1d98eaadbe4dd47c9f27674df9018cfd1.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_bafc11e1d98eaadbe4dd47c9f27674df9018cfd1.desktop</id>
+  <name>Todoist</name>
+  <launchable type="url">https://todoist.com/</launchable>
+  <url type="homepage">https://todoist.com/</url>
+  <summary>A to-do list to organize your work and life</summary>
+  <description>Trusted by 30 million people and teams. Todoist is the world's favorite task manager and to-do list app. Finally become focused, organized and calm.</description>
+  <project_license>LicenseRef-proprietary</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="192" height="192">https://todoist.com/static/android-chrome-192x192.png</icon>
+  <icon type="remote" width="256" height="256">https://todoist.com/static/android-chrome-256x256.png</icon>
+  <categories>
+    <category>Programming and Developer Software</category>
+  </categories>
+  <keywords>
+    <keyword>Office</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_dd7b0c5ff0c21c2984f8fc1a05d01c33aee4fe9d.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_dd7b0c5ff0c21c2984f8fc1a05d01c33aee4fe9d.metainfo.xml
@@ -4,10 +4,11 @@
   <name>GNOME Discourse</name>
   <launchable type="url">https://discourse.gnome.org/</launchable>
   <url type="homepage">https://discourse.gnome.org/</url>
-  <summary>GNOME Discourse</summary>
+  <summary>A forum for GNOME users</summary>
   <description>GNOME Project and Community related discussions</description>
   <project_license>GPL-2.0-or-later</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>The GNOME Project</developer_name>
   <icon type="remote" width="512" height="512">https://discourse-gnome-org-uploads.s3.dualstack.us-east-2.amazonaws.com/optimized/1X/d7f8fbabd4cd13f5fdbf7c73bd203723a2ef36ea_2_512x512.png</icon>
   <categories>
     <category>Chat</category>

--- a/app-info/metainfo/org.gnome.Software.WebApp_dd7b0c5ff0c21c2984f8fc1a05d01c33aee4fe9d.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_dd7b0c5ff0c21c2984f8fc1a05d01c33aee4fe9d.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_dd7b0c5ff0c21c2984f8fc1a05d01c33aee4fe9d.desktop</id>
+  <name>GNOME Discourse</name>
+  <launchable type="url">https://discourse.gnome.org/</launchable>
+  <url type="homepage">https://discourse.gnome.org/</url>
+  <summary>GNOME Discourse</summary>
+  <description>GNOME Project and Community related discussions</description>
+  <project_license>GPL-2.0-or-later</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="512" height="512">https://discourse-gnome-org-uploads.s3.dualstack.us-east-2.amazonaws.com/optimized/1X/d7f8fbabd4cd13f5fdbf7c73bd203723a2ef36ea_2_512x512.png</icon>
+  <categories>
+    <category>Chat</category>
+  </categories>
+  <keywords>
+    <keyword>GNOME</keyword>
+    <keyword>forum</keyword>
+    <keyword>support</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+    <content_attribute id="social-audio">moderate</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e41134be0ce95da0832878faa90cf3473b1b52d7.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e41134be0ce95da0832878faa90cf3473b1b52d7.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_e41134be0ce95da0832878faa90cf3473b1b52d7.desktop</id>
+  <name>Squoosh</name>
+  <launchable type="url">https://squoosh.app/</launchable>
+  <url type="homepage">https://squoosh.app/</url>
+  <summary>Squoosh</summary>
+  <description>Squoosh is the ultimate image optimizer that allows you to compress and compare images with different codecs in your browser.</description>
+  <project_license>Apache-2.0</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="1024" height="1024">https://squoosh.app/c/icon-large-cb438cac.png</icon>
+  <screenshots>
+    <screenshot type="default">
+      <image width="540" height="720">https://squoosh.app/c/screenshot1-0ff68546.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="540" height="720">https://squoosh.app/c/screenshot2-1f78c4db.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image width="540" height="720">https://squoosh.app/c/screenshot3-c1e02216.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image width="1024" height="593">https://squoosh.app/c/screenshot4-3a706c3c.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="1024" height="593">https://squoosh.app/c/screenshot5-ea50826f.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image width="1024" height="593">https://squoosh.app/c/screenshot6-0168d284.jpg</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Graphics Multimedia and Web Design</category>
+    <category>Photography</category>
+    <category>Office</category>
+    <category>Utility</category>
+  </categories>
+  <keywords>
+    <keyword>FileTools</keyword>
+    <keyword>Image</keyword>
+    <keyword>Processing</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e41134be0ce95da0832878faa90cf3473b1b52d7.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e41134be0ce95da0832878faa90cf3473b1b52d7.metainfo.xml
@@ -4,10 +4,11 @@
   <name>Squoosh</name>
   <launchable type="url">https://squoosh.app/</launchable>
   <url type="homepage">https://squoosh.app/</url>
-  <summary>Squoosh</summary>
+  <summary>An image compression web app that reduces image sizes through numerous formats</summary>
   <description>Squoosh is the ultimate image optimizer that allows you to compress and compare images with different codecs in your browser.</description>
   <project_license>Apache-2.0</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Surma</developer_name>
   <icon type="remote" width="1024" height="1024">https://squoosh.app/c/icon-large-cb438cac.png</icon>
   <screenshots>
     <screenshot type="default">

--- a/app-info/metainfo/org.gnome.Software.WebApp_e636aa5f2069f6e9c02deccc7b65f43da7985e32.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e636aa5f2069f6e9c02deccc7b65f43da7985e32.metainfo.xml
@@ -4,10 +4,11 @@
   <name>Pinafore for Mastodon</name>
   <launchable type="url">https://pinafore.social/</launchable>
   <url type="homepage">https://pinafore.social/</url>
-  <summary>An alternative web client for Mastodon, focused on speed and simplicity</summary>
-  <description>An alternative web client for Mastodon, focused on speed and simplicity.</description>
+  <summary>An alternative web client for Mastodon</summary>
+  <description>Pinafore is an alternative web client for Mastodon that focuses on speed, simplicity, Multi-account Support, Offline Usability, Mobile Support, and User Privacy.</description>
   <project_license>AGPL-3.0-only</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Nolan Lawson</developer_name>
   <icon type="remote" width="48" height="48">https://pinafore.social/icon-48.png</icon>
   <icon type="remote" width="72" height="72">https://pinafore.social/icon-72.png</icon>
   <icon type="remote" width="96" height="96">https://pinafore.social/icon-96.png</icon>
@@ -31,6 +32,14 @@
   <categories>
     <category>Chat</category>
   </categories>
+  <keywords>
+    <keyword>Fast</keyword>
+    <keyword>Simple</keyword>
+    <keyword>Mastodon</keyword>
+    <keyword>Multi-Account Support</keyword>
+    <keyword>Offline Compatible</keyword>
+    <keyword>Private</keyword>
+  </keywords>
   <content_rating type="oars-1.1">
     <content_attribute id="social-audio">intense</content_attribute>
     <content_attribute id="social-info">none</content_attribute>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e636aa5f2069f6e9c02deccc7b65f43da7985e32.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e636aa5f2069f6e9c02deccc7b65f43da7985e32.metainfo.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_e636aa5f2069f6e9c02deccc7b65f43da7985e32.desktop</id>
+  <name>Pinafore for Mastodon</name>
+  <launchable type="url">https://pinafore.social/</launchable>
+  <url type="homepage">https://pinafore.social/</url>
+  <summary>An alternative web client for Mastodon, focused on speed and simplicity</summary>
+  <description>An alternative web client for Mastodon, focused on speed and simplicity.</description>
+  <project_license>AGPL-3.0-only</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="48" height="48">https://pinafore.social/icon-48.png</icon>
+  <icon type="remote" width="72" height="72">https://pinafore.social/icon-72.png</icon>
+  <icon type="remote" width="96" height="96">https://pinafore.social/icon-96.png</icon>
+  <icon type="remote" width="144" height="144">https://pinafore.social/icon-144.png</icon>
+  <icon type="remote" width="192" height="192">https://pinafore.social/icon-192.png</icon>
+  <icon type="remote" width="512" height="512">https://pinafore.social/icon-512.png</icon>
+  <icon type="remote" width="44" height="44">https://pinafore.social/icon-44.png</icon>
+  <icon type="remote" width="50" height="50">https://pinafore.social/icon-50.png</icon>
+  <icon type="remote" width="150" height="150">https://pinafore.social/icon-150.png</icon>
+  <screenshots>
+    <screenshot type="default">
+      <image width="540" height="720">https://pinafore.social/screenshot-540-720-1.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="540" height="720">https://pinafore.social/screenshot-540-720-2.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="540" height="720">https://pinafore.social/screenshot-540-720-3.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Chat</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e730d810bf154c7818b460479ea7826140099a7a.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e730d810bf154c7818b460479ea7826140099a7a.metainfo.xml
@@ -4,14 +4,15 @@
   <name>Instagram</name>
   <launchable type="url">https://www.instagram.com/</launchable>
   <url type="homepage">https://www.instagram.com/</url>
-  <summary>Instagram</summary>
-  <description>Create an account or log in to Instagram - A simple, fun &amp; creative way to capture, edit &amp; share photos, videos &amp; messages with friends &amp; family.</description>
+  <summary>Give people the power to build community and bring the world closer together</summary>
+  <description>A simple, fun &amp; creative way to capture, edit &amp; share photos, videos &amp; messages with friends &amp; family.</description>
   <project_license>LicenseRef-proprietary</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Instagram</developer_name>
   <icon type="remote" width="144" height="144">https://www.instagram.com/static/images/ico/xxhdpi_launcher.png/99cf3909d459.png</icon>
   <icon type="remote" width="192" height="192">https://www.instagram.com/static/images/ico/xxxhdpi_launcher.png/9fc4bab7565b.png</icon>
   <categories>
-    <category>Chat</category>
+    <category>Chat, InstantMessaging, Video, Audio</category>
   </categories>
   <keywords>
     <keyword>Photography</keyword>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e730d810bf154c7818b460479ea7826140099a7a.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e730d810bf154c7818b460479ea7826140099a7a.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_e730d810bf154c7818b460479ea7826140099a7a.desktop</id>
+  <name>Instagram</name>
+  <launchable type="url">https://www.instagram.com/</launchable>
+  <url type="homepage">https://www.instagram.com/</url>
+  <summary>Instagram</summary>
+  <description>Create an account or log in to Instagram - A simple, fun &amp; creative way to capture, edit &amp; share photos, videos &amp; messages with friends &amp; family.</description>
+  <project_license>LicenseRef-proprietary</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="144" height="144">https://www.instagram.com/static/images/ico/xxhdpi_launcher.png/99cf3909d459.png</icon>
+  <icon type="remote" width="192" height="192">https://www.instagram.com/static/images/ico/xxxhdpi_launcher.png/9fc4bab7565b.png</icon>
+  <categories>
+    <category>Chat</category>
+  </categories>
+  <keywords>
+    <keyword>Photography</keyword>
+    <keyword>Graphics</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="sex-themes">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-location">intense</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+    <content_attribute id="money-advertising">intense</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e7aada0261449b5239c5c458c48fe92717950d1a.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e7aada0261449b5239c5c458c48fe92717950d1a.metainfo.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_e7aada0261449b5239c5c458c48fe92717950d1a.desktop</id>
+  <name>StackEdit</name>
+  <launchable type="url">https://stackedit.io/app</launchable>
+  <url type="homepage">https://stackedit.io/app</url>
+  <summary>Full-featured, open-source Markdown editor</summary>
+  <description>Free, open-source, full-featured Markdown editor.</description>
+  <project_license>Apache-2.0</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="512" height="512">https://stackedit.io/icon_512x512.bc1452c3b77b59eb0d8c449de1c77310.png</icon>
+  <icon type="remote" width="384" height="384">https://stackedit.io/icon_384x384.3f55b77300c8b37b4aa380c8460ee0a2.png</icon>
+  <icon type="remote" width="256" height="256">https://stackedit.io/icon_256x256.f406288343ae34c5c7bd1543700c2ac0.png</icon>
+  <icon type="remote" width="192" height="192">https://stackedit.io/icon_192x192.eec0feaecc5bef1a499b3de11bde6b27.png</icon>
+  <icon type="remote" width="128" height="128">https://stackedit.io/icon_128x128.43ad56ce3535a3ffe333a76a05c13267.png</icon>
+  <icon type="remote" width="96" height="96">https://stackedit.io/icon_96x96.1d93fc90dc62ceec6c921786ddab3f69.png</icon>
+  <categories>
+    <category>Programming and Developer Software</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/metainfo/org.gnome.Software.WebApp_e7aada0261449b5239c5c458c48fe92717950d1a.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_e7aada0261449b5239c5c458c48fe92717950d1a.metainfo.xml
@@ -4,10 +4,11 @@
   <name>StackEdit</name>
   <launchable type="url">https://stackedit.io/app</launchable>
   <url type="homepage">https://stackedit.io/app</url>
-  <summary>Full-featured, open-source Markdown editor</summary>
-  <description>Free, open-source, full-featured Markdown editor.</description>
+  <summary>Free, open-source, full-featured Markdown editor</summary>
+  <description>Full-featured, open-source Markdown editor based on PageDown, the Markdown library used by Stack Overflow and the other Stack Exchange sites.</description>
   <project_license>Apache-2.0</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Dock5 Software Ltd.</developer_name>
   <icon type="remote" width="512" height="512">https://stackedit.io/icon_512x512.bc1452c3b77b59eb0d8c449de1c77310.png</icon>
   <icon type="remote" width="384" height="384">https://stackedit.io/icon_384x384.3f55b77300c8b37b4aa380c8460ee0a2.png</icon>
   <icon type="remote" width="256" height="256">https://stackedit.io/icon_256x256.f406288343ae34c5c7bd1543700c2ac0.png</icon>
@@ -17,6 +18,11 @@
   <categories>
     <category>Programming and Developer Software</category>
   </categories>
+  <keywords>
+    <keyword>markdown</keyword>
+    <keyword>editor</keyword>
+    <keyword>open-source</keyword>
+  </keywords>
   <content_rating type="oars-1.1">
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>

--- a/app-info/metainfo/org.gnome.Software.WebApp_ea52ad18346faac27072cd1654243dfb7c70ef14.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_ea52ad18346faac27072cd1654243dfb7c70ef14.metainfo.xml
@@ -4,10 +4,11 @@
   <name>Excalidraw</name>
   <launchable type="url">https://excalidraw.com/</launchable>
   <url type="homepage">https://excalidraw.com/</url>
-  <summary>Excalidraw — Collaborative whiteboarding made easy</summary>
+  <summary>Collaborative whiteboarding made easy</summary>
   <description>Excalidraw is a virtual collaborative whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them.</description>
   <project_license>MIT</project_license>
   <metadata_license>FSFAP</metadata_license>
+  <developer_name>Excalidraw</developer_name>
   <icon type="remote" width="180" height="180">https://excalidraw.com/logo-180x180.png</icon>
   <icon type="remote" width="256" height="256">https://excalidraw.com/apple-touch-icon.png</icon>
   <screenshots>

--- a/app-info/metainfo/org.gnome.Software.WebApp_ea52ad18346faac27072cd1654243dfb7c70ef14.metainfo.xml
+++ b/app-info/metainfo/org.gnome.Software.WebApp_ea52ad18346faac27072cd1654243dfb7c70ef14.metainfo.xml
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="web-application">
+  <id>org.gnome.Software.WebApp_ea52ad18346faac27072cd1654243dfb7c70ef14.desktop</id>
+  <name>Excalidraw</name>
+  <launchable type="url">https://excalidraw.com/</launchable>
+  <url type="homepage">https://excalidraw.com/</url>
+  <summary>Excalidraw — Collaborative whiteboarding made easy</summary>
+  <description>Excalidraw is a virtual collaborative whiteboard tool that lets you easily sketch diagrams that have a hand-drawn feel to them.</description>
+  <project_license>MIT</project_license>
+  <metadata_license>FSFAP</metadata_license>
+  <icon type="remote" width="180" height="180">https://excalidraw.com/logo-180x180.png</icon>
+  <icon type="remote" width="256" height="256">https://excalidraw.com/apple-touch-icon.png</icon>
+  <screenshots>
+    <screenshot type="default">
+      <image width="462" height="945">https://excalidraw.com/screenshots/virtual-whiteboard.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="462" height="945">https://excalidraw.com/screenshots/wireframe.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="462" height="945">https://excalidraw.com/screenshots/illustration.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="462" height="945">https://excalidraw.com/screenshots/shapes.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="462" height="945">https://excalidraw.com/screenshots/collaboration.png</image>
+    </screenshot>
+    <screenshot>
+      <image width="462" height="945">https://excalidraw.com/screenshots/export.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Programming and Developer Software</category>
+  </categories>
+  <keywords>
+    <keyword>Office</keyword>
+    <keyword>Education</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+    <display_length compare="ge">small</display_length>
+  </recommends>
+</component>

--- a/app-info/pwa-metainfo-generator.py
+++ b/app-info/pwa-metainfo-generator.py
@@ -132,41 +132,26 @@ def get_manifest(soup, url):
 
 
 def og_property_from_head(soup, og_property):
-    prop = soup.head.find_all("meta", {"property": "og:" + str(og_property)})
+    tag = soup.head.find("meta", attrs={"property": f"og:{og_property}"})
 
-    if len(prop) > 0:
-        prop = prop[0]['content']
-
-    return prop
+    if tag is None:
+        return None
+    return tag.get("content")
 
 
 def prop_from_head(soup, name):
-    prop = soup.head.find_all("meta", {"name": name})
+    tag = soup.head.find("meta", attrs={"name": f"{name}"})
 
-    if len(prop) > 0:
-        prop = prop[0]['content']
-    else:
-        prop = soup.head.find_all("meta", {"name": name.capitalize()})
-
-        if len(prop) > 0:
-            prop = prop[0]['content']
-
-    return prop
+    if tag is None:
+        return None
+    return tag.get("content")
 
 
 def keywords_from_head(soup):
-    keywords = soup.head.find("meta", attrs={"name": "Keywords"})
+    keywords_value = prop_from_head(soup, "keywords")
 
-    if keywords is None:
-        keywords = soup.head.find("meta", attrs={"name": "keywords"})
-        if keywords is None:
-            keywords = []
-        elif "meta" in str(keywords):
-            keywords = keywords['content'].split(", ")
-        else:
-            keywords = []
-    elif "meta" in str(keywords):
-        keywords = keywords['content'].split(", ")
+    if keywords_value:
+        keywords = keywords_value.split(", ")
     else:
         keywords = []
 

--- a/app-info/pwa-metainfo-generator.py
+++ b/app-info/pwa-metainfo-generator.py
@@ -132,21 +132,42 @@ def get_manifest(soup, url):
 
 
 def og_property_from_head(soup, og_property):
-    return soup.head.find_all(
-        "meta",
-        {"property": "og:" + str(og_property)},
-    )[0]['content']
+    prop = soup.head.find_all("meta", {"property": "og:" + str(og_property)})
+
+    if len(prop) > 0:
+        prop = prop[0]['content']
+
+    return prop
+
+
+def prop_from_head(soup, name):
+    prop = soup.head.find_all("meta", {"name": name})
+
+    if len(prop) > 0:
+        prop = prop[0]['content']
+    else:
+        prop = soup.head.find_all("meta", {"name": name.capitalize()})
+
+        if len(prop) > 0:
+            prop = prop[0]['content']
+
+    return prop
 
 
 def keywords_from_head(soup):
-    try:
-        # Try to set keywords to the contents of keywords meta element from the header
-        keywords = soup.head.find(
-            "meta",
-            attrs={"name": "keywords"},
-        )['content'].split(", ")
-    except TypeError:
-        # Set keywords to empty list if no keyword meta elements
+    keywords = soup.head.find("meta", attrs={"name": "Keywords"})
+
+    if keywords is None:
+        keywords = soup.head.find("meta", attrs={"name": "keywords"})
+        if keywords is None:
+            keywords = []
+        elif "meta" in str(keywords):
+            keywords = keywords['content'].split(", ")
+        else:
+            keywords = []
+    elif "meta" in str(keywords):
+        keywords = keywords['content'].split(", ")
+    else:
         keywords = []
 
     return keywords


### PR DESCRIPTION
Added sites from the gnome-pwa-lists to [eos-extra-pwa.yaml](https://github.com/endlessm/gnome-software-data/blob/master/app-info/eos-extra-pwa.yaml) and made the from_head functions a bit more robust and versatile

https://phabricator.endlessm.com/T34555